### PR TITLE
Increase counter

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -4,13 +4,16 @@ var players = [];
 
 chrome.storage.sync.get({
   numTurns: 10,
-  showAllChanges: false
+  showAllChanges: false,
+  useCountDown: false
 }, function(items) {
   NUM_TURNS = items.numTurns;
   SHOW_ALL_CHANGES = items.showAllChanges;
+  USE_COUNTDOWN = items.useCountDown;
 });
 
 addedCityLabel = false
+addedTurnCounter = false
 
 // mode: https://stackoverflow.com/a/3783970
 function mode(array) {
@@ -31,6 +34,18 @@ function inGame(){
   return document.getElementById("game-leaderboard");
 }
 
+function getNextIncrease(){
+  var turnCounter = document.getElementById('turn-counter');
+  var currentTurn = parseInt(turnCounter.textContent.split(' ')[1]);
+  if(USE_COUNTDOWN){
+    var turnsLeft = 25 - (currentTurn % 25);
+  } else {
+    var turnsLeft = 25 - (currentTurn % 25) + parseInt(currentTurn);
+  }
+  ;
+  return " Next Increase: " + turnsLeft;
+}
+
 function getArmy(player){
   var leaderboard = document.getElementById('game-leaderboard');
   var player_cell = leaderboard.querySelectorAll('.leaderboard-name.' + player);
@@ -45,7 +60,7 @@ function updateCities(player, cities){
   // Add flash if cities increase to > 0 or SHOW_ALL_CHANGES set
   if ((SHOW_ALL_CHANGES && parseInt(cities_cell[0].innerHTML) !== cities)
       || (cities_cell[0].innerHTML == "0" && cities > 0)) {
-    setTimeout(function(row, cl) { row.className = cl; }, 
+    setTimeout(function(row, cl) { row.className = cl; },
       1000, player_row, player_row.className);
     player_row.className += " flash " + player;
   }
@@ -54,6 +69,7 @@ function updateCities(player, cities){
 
 function turn(){
   var leaderboard = document.getElementById('game-leaderboard');
+  var turnCounter = document.getElementById('turn-counter');
 
   // Initialise columns
   if(!addedCityLabel){
@@ -74,6 +90,17 @@ function turn(){
     addedCityLabel = true;
   }
 
+  // add Turn Counter
+  if(!addedTurnCounter) {
+    var nextIncrease = document.createElement('div');
+    nextIncrease.id = "nextIncreaseCounter";
+    turnCounter.appendChild(nextIncrease);
+
+    addedTurnCounter = true;
+  }
+  var nextIncreaseCounter = document.getElementById('nextIncreaseCounter');
+  nextIncreaseCounter.textContent = getNextIncrease();
+
   // Update city counts
   for(var i = 0; i < players.length; i++) {
     var player = players[i];
@@ -93,7 +120,7 @@ function turn(){
         // Calculate number of cities
         if(data[player].length >= NUM_TURNS) {
           var guess_cities = mode(data[player].slice(data[player].length - NUM_TURNS));
-          updateCities(player, guess_cities - 1); 
+          updateCities(player, guess_cities - 1);
         }
       }
     }
@@ -105,6 +132,7 @@ turnInterval = setInterval(function() {
     turn();
   } else {
     addedCityLabel = false
+    addedTurnCounter = false
     data = {};
     last = {};
     players = [];

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 
 {
   "name": "Generals.io City Counter",
-  "description": "Displays an estimated city count next to each player on Generals.io",
-  "version": "1.3",
+  "description": "Displays an estimated city count next to each player on Generals.io and add a counter for the next army increase.",
+  "version": "1.4",
   "permissions": [
     "activeTab",
     "storage"

--- a/options.html
+++ b/options.html
@@ -14,6 +14,12 @@
   <label>
     Flash for every city update? &nbsp;<input type="checkbox" id="showAllChanges">
   </label>
+  <br />
+  
+  <label>
+    Use Countdown instead of Turn Number &nbsp;<input type="checkbox"
+    id="useCountDown">
+  </label>
   <br /><br />
 
   <button id="save">Save</button>

--- a/options.js
+++ b/options.js
@@ -2,10 +2,11 @@
 function save_options() {
   chrome.storage.sync.set({
     numTurns: document.getElementById('numTurns').value,
-    showAllChanges: document.getElementById('showAllChanges').checked
+    showAllChanges: document.getElementById('showAllChanges').checked,
+    useCountDown: document.getElementById('useCountDown').checked
   }, function() {
     document.getElementById('status').textContent = 'Options saved.';
-    setTimeout(function() { 
+    setTimeout(function() {
       document.getElementById('status').textContent = '';
     }, 750);
   });
@@ -15,10 +16,12 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get({
     numTurns: 10,
-    showAllChanges: false
+    showAllChanges: false,
+    useCountDown: false
   }, function(items) {
     document.getElementById('numTurns').value = items.numTurns;
     document.getElementById('showAllChanges').checked = items.showAllChanges;
+    document.getElementById('useCountDown').checked = items.useCountDown;
   });
 }
 


### PR DESCRIPTION
I added a counter to the Turns field on the top-left corner.
this counter tells the player how many turns are left until all tiles get an additional resource point.

at first i made it into a countdown, but that looked horrible because the extension turn interval deviated from the react turn interval which actually displays the turns.

i was also thinking of maybe adding a rough estimate for possible attack sizes (i.e. enemy army size - tiles), but thats not part of this request :) 


